### PR TITLE
chore(ci): update of CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   CLAAssistant:
-    if: github.event.pull_request.draft == false
     permissions:
       actions: write
       contents: write
@@ -21,7 +20,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 #v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}


### PR DESCRIPTION
Pinned `contributor-assistant/github-action` version to v2.6.1 SHA
<!-- start messages -->
### Commit messages:
[web-flow](https://github.com/Netcracker/qubership-testing-platform-ss7-transport-library/commit/66d8f576339932898e7114f9db715819d83a4850) chore(ci): update of CLA workflow
Pinned `contributor-assistant/github-action` version to v2.6.1 SHA
<!-- end messages -->
